### PR TITLE
fixed the random rotation augmentation inconsistency

### DIFF
--- a/detectree2/models/train.py
+++ b/detectree2/models/train.py
@@ -463,9 +463,8 @@ class MyTrainer(DefaultTrainer):
 
         # Define basic augmentations including rotation and flipping
         augmentations = [
-            T.RandomRotation(angle=[90, 90], expand=False),
-            T.RandomFlip(prob=0.4, horizontal=True, vertical=False),
-            T.RandomFlip(prob=0.4, horizontal=False, vertical=True),
+            T.RandomRotation(angle=[0, 360], expand=False),
+            T.RandomFlip(prob=0.5, horizontal=True, vertical=False),
         ]
 
         # Additional augmentations for RGB images

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -474,9 +474,8 @@ By default, random rotations and flips will be performed on input images.
 .. code-block:: python
 
    augmentations = [
-      T.RandomRotation(angle=[90, 90], expand=False),
-      T.RandomFlip(prob=0.4, horizontal=True, vertical=False),
-      T.RandomFlip(prob=0.4, horizontal=False, vertical=True),
+      T.RandomRotation(angle=[0, 360], expand=False),
+      T.RandomFlip(prob=0.5, horizontal=True, vertical=False),
    ]
 
 If the input data is RGB, additional augmentations will be applied to adjust the brightness, contrast, saturation, and


### PR DESCRIPTION
## Update Augmentation Pipeline to Improve Coverage and Efficiency

### Description of Changes
- Updated `RandomRotation` to cover a full 360-degree range (`angle=[0, 360], sample_style="range"`), replacing the previous fixed `[90, 90]` which provided no rotation augmentation.
- Adjusted `RandomFlip` probability from `0.4` to `0.5` for a simpler and more balanced augmentation strategy.
- Simplified flipping to use a single `RandomFlip` with `horizontal=True` instead of separate horizontal and vertical flips.

### Justification
1. **Rotation Augmentation**: The previous configuration with `[90, 90]` effectively applied no rotation variation. The updated 360-degree range ensures diverse rotations and better augmentation coverage.
2. **Flip Probability Change**: A probability of `0.5` aligns with the standard approach, ensuring equal chances of flipping or not flipping, which simplifies implementation and interpretation.
3. **Single Flip Augmentation**: A single horizontal flip is sufficient to achieve all unique mirroring transformations when combined with 360-degree rotations. Adding a separate vertical flip would be redundant.

### Impact
This change improves the diversity and efficiency of the augmentation pipeline, ensuring a better-distributed dataset for training.
