### PR TITLE
Create an RGB clone of a MS Tiles Folder

### DIFF
--- a/detectree2/preprocessing/tiling.py
+++ b/detectree2/preprocessing/tiling.py
@@ -1020,6 +1020,13 @@ def create_RGB_from_MS(tile_folder_path: Union[str, Path],
             logger.warning(f" - Size in subdir: {sub_size} bytes")
             logger.warning(f" - Size in out_dir: {main_size} bytes")
 
+    
+    # Copy anything that is not a .tif, .png or .geojson file to the output folder (ignore folders)
+    for file in tile_folder.glob("*"):
+        if file.is_file() and file.suffix not in [".tif", ".png", ".geojson"]:
+            shutil.copy(str(file), str(out_path))
+
+
     logger.info("RGB creation from multispectral complete.")
 
 

--- a/detectree2/preprocessing/tiling.py
+++ b/detectree2/preprocessing/tiling.py
@@ -1020,12 +1020,10 @@ def create_RGB_from_MS(tile_folder_path: Union[str, Path],
             logger.warning(f" - Size in subdir: {sub_size} bytes")
             logger.warning(f" - Size in out_dir: {main_size} bytes")
 
-    
     # Copy anything that is not a .tif, .png or .geojson file to the output folder (ignore folders)
     for file in tile_folder.glob("*"):
         if file.is_file() and file.suffix not in [".tif", ".png", ".geojson"]:
             shutil.copy(str(file), str(out_path))
-
 
     logger.info("RGB creation from multispectral complete.")
 


### PR DESCRIPTION
This pull request introduces a new function to the `detectree2/preprocessing/tiling.py` file to convert multispectral GeoTIFF tiles into three-band RGB images. It also includes some minor import adjustments. 

New Functionality:
* Added `create_RGB_from_MS` function to convert multispectral GeoTIFF tiles into three-band RGB images using either PCA or by selecting the first three bands. 
