### PR TITLE
Fixed failing Pytest

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,7 +6,7 @@ name: Detectree2 CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "chris/pytest-fix" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,7 +6,7 @@ name: Detectree2 CI
 
 on:
   push:
-    branches: [ "master", "chris/pytest-fix" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/detectree2/tests/test_preprocessing.py
+++ b/detectree2/tests/test_preprocessing.py
@@ -90,7 +90,7 @@ class TestCase(unittest.TestCase):
         from detectree2.preprocessing.tiling import image_details
         xbox_coords, ybox_coords = image_details(file_root)
         self.assertEqual(xbox_coords, (286539, 286609))
-        self.assertEqual(ybox_coords, (583712, 583782))
+        self.assertEqual(ybox_coords, (583752, 583822))
 
     # @pytest.mark.dependency(depends=["test_tiling"]) # SKIPS tests - does not resolve order
     @pytest.mark.order(3)


### PR DESCRIPTION
Done so by adjusting the to new, correct coordinates, as with the new tiling code, the convex hull removes enough image data for the original tile to fall over the nodata-threshold.