### PR TITLE
Optimize `clean_crowns` Performance with Spatial Index, Significantly Reduce Processing Time

### DIFF
--- a/detectree2/models/evaluation.py
+++ b/detectree2/models/evaluation.py
@@ -424,6 +424,8 @@ def find_intersections(all_test_feats, all_pred_feats):
                         continue
 
                 # calculate the IoU
+                if union_area == 0:
+                    continue    
                 IoU = intersection / union_area
 
                 # update the objects so they only store greatest intersection value

--- a/detectree2/models/outputs.py
+++ b/detectree2/models/outputs.py
@@ -19,8 +19,10 @@ import pycocotools.mask as mask_util
 import rasterio
 from rasterio.crs import CRS
 from shapely.affinity import scale
+from shapely.errors import GEOSException
 from shapely.geometry import Polygon, box, shape
 from shapely.ops import orient
+from tqdm import tqdm
 
 # Type aliases definitions
 Feature = Dict[str, Any]
@@ -316,10 +318,7 @@ def stitch_crowns(folder: str, shift: int = 1):
     total_files = len(files)
     crowns_list = []
 
-    for idx, file in enumerate(files, start=1):
-        if idx % 50 == 0:
-            print(f"Stitching file {idx} of {total_files}: {file}")
-
+    for file in tqdm(files, desc="Stitching Crowns", total=total_files):
         crowns_tile = gpd.read_file(file)  # This throws a huge amount of warnings fiona closed ring detected
 
         geo = box_filter(file, shift)


### PR DESCRIPTION
Currently, the `detectree2.models.outputs.clean_crowns()` function cleans crowns by iterating over all the canopies and comparing each one with every other using the `intersects()` method. This approach has a time complexity of **O(n²)**, which results in extremely long processing times as the number of canopy increases (over 100 hours for 1M canopies).

This pull request introduces two key optimizations:

- **Spatial Index:**  
  By leveraging a spatial index, the `intersects()` method is applied only to those canopies whose bounding boxes intersect with the canopy under consideration. This optimization reduces the time complexity to **O(n log n)**, cutting the processing time down to roughly 1 hour for 1M canopies.

- **Checked Crowns Set:**  
  A `checked_crowns` set has been implemented to track previously compared canopies, preventing redundant intersection calculations and further reducing processing time.

These improvements significantly enhance the performance and scalability of the crown cleaning process.